### PR TITLE
Remove _path from query parameters when fragment is a subrequest and request attributes are already set

### DIFF
--- a/EventListener/FragmentListener.php
+++ b/EventListener/FragmentListener.php
@@ -57,7 +57,13 @@ class FragmentListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if ($request->attributes->has('_controller') || $this->fragmentPath !== rawurldecode($request->getPathInfo())) {
+        if ($this->fragmentPath !== rawurldecode($request->getPathInfo())) {
+            return;
+        }
+
+        if ($request->attributes->has('_controller')) {
+            // Is a sub-request: no need to parse _path but it should still be removed from query parameters as below.
+            $request->query->remove('_path');
             return;
         }
 


### PR DESCRIPTION
Without removing the _path query parameter, ESI handled through an actual proxy (Varnish, for example) behave differently than ESI handled when the proxy is not available (and thus the fragment is a subrequest instead of a master request).