### PR TITLE
[HttpKernel] enabling cache-reloading when cache file is rebuilt

### DIFF
--- a/Kernel.php
+++ b/Kernel.php
@@ -479,15 +479,34 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $class = $this->getContainerClass();
         $cache = new ConfigCache($this->getCacheDir().'/'.$class.'.php', $this->debug);
         $fresh = true;
+        $unversionedClass = $class;
         if (!$cache->isFresh()) {
             $container = $this->buildContainer();
             $container->compile();
+            $class = $this->getNextClassVersion($class);
             $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 
             $fresh = false;
+        } else {
+            $class = $this->getLatestClassVersion($class);
         }
 
-        require_once $cache->getPath();
+        if(!class_exists($class)) {
+            require $cache->getPath();
+        }
+
+        if(!class_exists($class)) {
+            //the cache file loaded has a different classVersion than we expected, so we need to find the loaded class.
+            foreach (array_reverse(get_declared_classes()) as $declaredClass) {
+                if (rtrim($declaredClass, '0123456789') === $unversionedClass) {
+                    class_alias($declaredClass, $class);
+                    break;
+                }
+            }
+            if (!class_exists($class)) {
+                throw new \RuntimeException(sprintf("Failed to load the %s container from cache\n", $class));
+            }
+        }
 
         $this->container = new $class();
         $this->container->set('kernel', $this);
@@ -495,6 +514,34 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         if (!$fresh && $this->container->has('cache_warmer')) {
             $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
         }
+    }
+
+    /**
+     * Returns the first version of the given class name that doesn't yet exist.
+     *
+     * eg. 'MyClass' is the first version, 'MyClass1' the second, 'MyClass2' the second, etc.
+     *
+     * @param string $class
+     * @return string
+     */
+    protected function getNextClassVersion($class)
+    {
+        for ($classVer = 0; class_exists($class . ($classVer ?: '')); $classVer++);
+
+        return $class . ($classVer ?: '');
+    }
+
+    /**
+     * Returns the last version of the given class name that does exist
+     *
+     * @param string $class
+     * @return string
+     */
+    protected function getLatestClassVersion($class)
+    {
+        for ($classVer = 0; class_exists($class . ($classVer ?: '')); $classVer++);
+
+        return $class . ($classVer > 1 ? $classVer - 1 : '');
     }
 
     /**


### PR DESCRIPTION
This allows the cache file to be deleted and thus rebuilt between Container builds in WebTestCase scenario, to enable testing of multiple configurations of the same application through WebTestCase.