### PR TITLE
~2.6 makes that 2.8 be a valid version of this requirement but this m…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.6,>=2.6.7",
         "symfony/http-foundation": "~2.5,>=2.5.4",
-        "symfony/debug": "~2.6,>=2.6.2",
+        "symfony/debug": ">=2.6.2, <2.7",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
…akes update PHP to a newer version

All symfony 2.6 require PHP 5.3.3 minimum 
symfony add "symfony/http-kernel" 2.6.* version
symfony/http-kernel add symfony/debug 2.8.* (because ~2.6)
and symfony/debug 2.8.* require PHP 5.3.9 and that is the error 
I wanted fix that