### PR TITLE
Update HttpCache.php

### DIFF
--- a/HttpCache/HttpCache.php
+++ b/HttpCache/HttpCache.php
@@ -687,11 +687,11 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     private function waitForLock(Request $request): bool
     {
         $wait = 0;
-        while ($this->store->isLocked($request) && $wait < 5000000) {
+        while ($this->store->isLocked($request) && $wait < 100) {
             usleep(50000);
-            $wait += 50000;
+            $wait += 1;
         }
 
-        return $wait < 5000000;
+        return $wait < 100;
     }
 }


### PR DESCRIPTION
simplification...
I guess the original Author was trying to pursue something like a martingale (doubling) strategy (or in this case the increment over a constant factor) but well ... he did not. Instead a constant wait time was introduced, which means the wait is simply executed a 100 times over (in the worst case). And so I do not see a need for "5000000" and "+= 50000" to remain here.