### PR TITLE
Symfony browser-kit in require dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher": "~3.4|~4.0",
-        "symfony/http-foundation": "~3.4.4|~4.0.4",
+        "psr/log": "~1.0",
+        "symfony/browser-kit": "~3.4|~4.0",
         "symfony/debug": "~3.4|~4.0",
-        "psr/log": "~1.0"
+        "symfony/event-dispatcher": "~3.4|~4.0",
+        "symfony/http-foundation": "~3.4.4|~4.0.4"
     },
     "require-dev": {
-        "symfony/browser-kit": "~3.4|~4.0",
+        "psr/cache": "~1.0",
         "symfony/config": "~3.4|~4.0",
         "symfony/console": "~3.4|~4.0",
         "symfony/css-selector": "~3.4|~4.0",
@@ -36,8 +37,7 @@
         "symfony/stopwatch": "~3.4|~4.0",
         "symfony/templating": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
-        "symfony/var-dumper": "~3.4|~4.0",
-        "psr/cache": "~1.0"
+        "symfony/var-dumper": "~3.4|~4.0"
     },
     "provide": {
         "psr/log-implementation": "1.0"


### PR DESCRIPTION
In [Client.php](https://github.com/symfony/http-kernel/blob/master/Client.php) there's browser kit used `use Symfony\Component\BrowserKit`

However, it is not explicitely required by this lib and I think it should be. I think it's a sub dependency and therefore shouldn't be necessary to require it as direct dependency in my project.

What are your thoughts?