### PR TITLE
Fix Kernel::locateResource method when name is empty.

### DIFF
--- a/Kernel.php
+++ b/Kernel.php
@@ -231,7 +231,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function locateResource($name, $dir = null, $first = true)
     {
-        if ('@' !== $name[0]) {
+        if (!isset($name[0]) || '@' !== $name[0]) {
             throw new \InvalidArgumentException(sprintf('A resource name must start with @ ("%s" given).', $name));
         }
 

--- a/Tests/KernelTest.php
+++ b/Tests/KernelTest.php
@@ -317,6 +317,16 @@ EOF;
         $this->assertEquals($expected, serialize($kernel));
     }
 
+	/**
+     * Test locateResource when name is empty.
+	 *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLocateResourceWhenNameIsEmpty()
+    {
+        $this->getKernel()->locateResource('');
+    }
+	
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
Fix Kernel::locateResource method when name is empty!