### PR TITLE
Added statusCode to parent::_contruct

### DIFF
--- a/Exception/HttpException.php
+++ b/Exception/HttpException.php
@@ -26,7 +26,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
         $this->statusCode = $statusCode;
         $this->headers = $headers;
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $statusCode, $previous);
     }
 
     public function getStatusCode()


### PR DESCRIPTION
I ran into a case where I got a `InvalidArgumentException(code: 0)` with the message:
`The HTTP status code "0" is not valid` while building the response for an exception of the type HttpException. 

As you can see, at the moment, the parent is getting the $code variable, which is not set. 
The thing that is being used is `$statusCode`. 

This leads to the following:

`$exception->getCode` results in 0
`$exception->getStatusCode` results in a http-status code, like 404.

Expected was the following:

`$exception->getCode` results in 404
`$exception->getStatusCode` results 404.

This problem only happens when people have a custom exception handler that expects that the inherited `getCode` method form the extended parent `Exception` class can be called...which in this case is being set to `0`, even though it is a HttpException.

So my proposed solution is to change the constructor 
from:

```php
    public function __construct(int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], ?int $code = 0)
    {
        $this->statusCode = $statusCode;
        $this->headers = $headers;

        parent::__construct($message, $code, $previous);
    }
```

to: 

```php
    public function __construct(int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], ?int $code = 0)
    {
        $this->statusCode = $statusCode;
        $this->headers = $headers;

        parent::__construct($message, $statusCode, $previous);
    }
```