### PR TITLE
Add type hint to write function

### DIFF
--- a/Kernel.php
+++ b/Kernel.php
@@ -454,7 +454,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                     $cache = new class($cachePath, $this->debug) extends ConfigCache {
                         public $lock;
 
-                        public function write($content, array $metadata = null)
+                        public function write(string $content, array $metadata = null)
                         {
                             rewind($this->lock);
                             ftruncate($this->lock, 0);


### PR DESCRIPTION
The declaration of the write function must match the interface.