### PR TITLE
Update HttpKernel.php

### DIFF
--- a/HttpKernel.php
+++ b/HttpKernel.php
@@ -61,7 +61,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      */
     public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true)
     {
-        $request->headers->set('X-Php-Ob-Level', ob_get_level());
+        $request->headers->set('X-Php-Ob-Level', strval(ob_get_level()));
 
         try {
             return $this->handleRaw($request, $type);


### PR DESCRIPTION
phpstan-symfony (0.11.6) level 5

Parameter #2 $values of method Symfony\Component\HttpFoundation\HeaderBag::set() expects array<string>|string, int given.