### PR TITLE
set Request locale from Accept-Language header being in an 'available_locales' array

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -31,10 +31,13 @@ class LocaleListener implements EventSubscriberInterface
 {
     private $router;
     private $defaultLocale;
+    private $availableLocales;
     private $requestStack;
 
-    public function __construct(RequestStack $requestStack, string $defaultLocale = 'en', RequestContextAwareInterface $router = null)
+    public function __construct(RequestStack $requestStack, string $defaultLocale = 'en', RequestContextAwareInterface $router = null, ?array $availableLocales = null)
     {
+        $this->defaultLocale = $defaultLocale;
+        $this->availableLocales = $availableLocales;
         $this->defaultLocale = $defaultLocale;
         $this->requestStack = $requestStack;
         $this->router = $router;
@@ -64,6 +67,11 @@ class LocaleListener implements EventSubscriberInterface
     {
         if ($locale = $request->attributes->get('_locale')) {
             $request->setLocale($locale);
+        }
+
+        if (null === $locale && null !== $this->availableLocales &&
+            $preferredLanguage = $request->getPreferredLanguage($this->availableLocales)) {
+           $request->setLocale($preferredLanguage);
         }
     }
 

--- a/Tests/EventListener/LocaleListenerTest.php
+++ b/Tests/EventListener/LocaleListenerTest.php
@@ -114,6 +114,67 @@ class LocaleListenerTest extends TestCase
         $this->assertEquals('de', $request->getLocale());
     }
 
+    public function testRequestPreferredLocaleFromAcceptLanguageHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', ['Accept-Language: fr-FR,fr;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6,es;q=0.5']);
+
+        $listener = new LocaleListener($this->requestStack, 'de', null, ['de', 'fr']);
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals('fr', $request->getLocale());
+    }
+
+    public function testRequestSecondPreferredLocaleFromAcceptLanguageHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', ['Accept-Language: fr-FR,fr;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6,es;q=0.5']);
+
+        $listener = new LocaleListener($this->requestStack, 'de', null, ['de', 'en']);
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals('en', $request->getLocale());
+    }
+
+    public function testRequestUnavailablePreferredLocaleFromAcceptLanguageHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', ['Accept-Language: fr-FR,fr;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6,es;q=0.5']);
+
+        $listener = new LocaleListener($this->requestStack, 'de', null, ['de', 'it']);
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals('de', $request->getLocale());
+    }
+
+    public function testRequestNoLocaleFromAcceptLanguageHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', ['Accept-Language: fr-FR,fr;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6,es;q=0.5']);
+
+        $listener = new LocaleListener($this->requestStack, 'de');
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals('de', $request->getLocale());
+    }
+
+    public function testRequestAttributeLocaleNotOverridenFromAcceptLanguageHeader()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('_locale', 'it');
+        $request->headers->set('Accept-Language', ['Accept-Language: fr-FR,fr;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6,es;q=0.5']);
+
+        $listener = new LocaleListener($this->requestStack, 'de', null, ['fr', 'en']);
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals('it', $request->getLocale());
+    }
+
     private function getEvent(Request $request): RequestEvent
     {
         return new RequestEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);


### PR DESCRIPTION
This `$availableLocales` value will come from a framework-bundle configuration entry `available_locales` along side `default_locale` and will be an (null by default) array.