### PR TITLE
catch \Throwable instead of \Exception

### DIFF
--- a/HttpKernel.php
+++ b/HttpKernel.php
@@ -73,7 +73,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $this->requestStack->push($request);
         try {
             return $this->handleRaw($request, $type);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             if ($e instanceof RequestExceptionInterface) {
                 $e = new BadRequestHttpException($e->getMessage(), $e);
             }


### PR DESCRIPTION
Catching `\Throwable` instead of `\Exception` can be more versatile. In case of `\TypeError` kernel won't catch it with possibility to handle it with `kernel.exception` listener.