### PR TITLE
Fix bug MapQueryString when request has only optional parameters

### DIFF
--- a/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -135,11 +135,16 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             }
 
             if (null === $payload) {
-                $payload = match (true) {
-                    $argument->metadata->hasDefaultValue() => $argument->metadata->getDefaultValue(),
-                    $argument->metadata->isNullable() => null,
-                    default => throw new HttpException($validationFailedCode)
-                };
+                try {
+                    $payload = match (true) {
+                        $argument->metadata->hasDefaultValue() => $argument->metadata->getDefaultValue(),
+                        !$argument->metadata->hasDefaultValue() => new ($argument->metadata->getType())(),
+                        $argument->metadata->isNullable() => null,
+                        default => throw new HttpException($validationFailedCode),
+                    };
+                } catch (\Throwable) {
+                    throw new HttpException($validationFailedCode);
+                }
             }
 
             $arguments[$i] = $payload;


### PR DESCRIPTION
Based on the discussion here https://github.com/symfony/symfony/issues/50690 I propose my solution