### PR TITLE
[HttpKernel] Resolve EBADP error on flock with LOCK_SH with NFS

### DIFF
--- a/Kernel.php
+++ b/Kernel.php
@@ -467,7 +467,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         try {
             is_dir($buildDir) ?: mkdir($buildDir, 0777, true);
 
-            if ($lock = fopen($cachePath.'.lock', 'w')) {
+            if ($lock = fopen($cachePath.'.lock', 'w+')) {
                 if (!flock($lock, \LOCK_EX | \LOCK_NB, $wouldBlock) && !flock($lock, $wouldBlock ? \LOCK_SH : \LOCK_EX)) {
                     fclose($lock);
                     $lock = null;


### PR DESCRIPTION
When using NFSv3 (with rpc.statd with NLM) or NFSv4, or any other filesystem where flock is converted to fcntl, performing flock LOCK_SH due to a would-be-blocking LOCK_EX will trigger EBADP and return false, and bypass the cache lock, due to the lock file not being opened with read mode. This causes cache locking to not have any effect on these filesystems.

Changing the lock file open to w+ resolve this issue and makes cache locking effective on NFS and other similar filesystems which convert flock calls to fcntl.

As per fcntl documentation: In order to place a read lock, fd must be open for reading. In order to place a write lock, fd must be open for writing. To place both types of lock, open a file read-write.

Fixes symfony/symfony#52144