### PR TITLE
Use template parameter in return type.

### DIFF
--- a/Event/ControllerArgumentsEvent.php
+++ b/Event/ControllerArgumentsEvent.php
@@ -94,13 +94,13 @@ final class ControllerArgumentsEvent extends KernelEvent
     }
 
     /**
-     * @template T of class-string|null
+     * @template T of object
      *
-     * @param T $className
+     * @param class-string<T>|null $className
      *
-     * @return array<class-string, list<object>>|list<object>
+     * @return array<class-string, list<object>>|list<T>
      *
-     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
+     * @psalm-return (T is null ? array<class-string, list<object>> : list<T>)
      */
     public function getAttributes(?string $className = null): array
     {

--- a/Event/ControllerEvent.php
+++ b/Event/ControllerEvent.php
@@ -79,13 +79,13 @@ final class ControllerEvent extends KernelEvent
     }
 
     /**
-     * @template T of class-string|null
+     * @template T of object
      *
-     * @param T $className
+     * @param class-string<T>|null $className
      *
-     * @return array<class-string, list<object>>|list<object>
+     * @return array<class-string, list<object>>|list<T>
      *
-     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
+     * @psalm-return (T is null ? array<class-string, list<object>> : list<T>)
      */
     public function getAttributes(?string $className = null): array
     {


### PR DESCRIPTION
This changes the doctype so that the template parameter is used in the return type. This allows type inference on the calling site without extra type hints.